### PR TITLE
Fix discord server links in challenges

### DIFF
--- a/weekday/challenge_262.md
+++ b/weekday/challenge_262.md
@@ -63,7 +63,7 @@ isSet([
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_263.md
+++ b/weekday/challenge_263.md
@@ -16,7 +16,7 @@ calculate_discount(100, 75) ➞ 25
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_264.md
+++ b/weekday/challenge_264.md
@@ -16,7 +16,7 @@ count_all("149990") ➞ { "LETTERS": 0, "DIGITS": 6 }
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_265.md
+++ b/weekday/challenge_265.md
@@ -14,7 +14,7 @@ str_match_by2char("", "") ➞ 0
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_266.md
+++ b/weekday/challenge_266.md
@@ -12,7 +12,7 @@ largest_even([0, 19, 18973623]) ➞ 0
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_267.md
+++ b/weekday/challenge_267.md
@@ -19,7 +19,7 @@ will_hit("y = 2x + 6", (3, 2)) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_268.md
+++ b/weekday/challenge_268.md
@@ -20,7 +20,7 @@ is_jackpot(("SS", "SS", "SS", "Ss")) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_269.md
+++ b/weekday/challenge_269.md
@@ -21,7 +21,7 @@ get_length([1, [2], 1, [2], 1]) ➞ 5
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_270.md
+++ b/weekday/challenge_270.md
@@ -18,7 +18,7 @@ countSameEnds("No I am not in a gang.") ➞ 1
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_271.md
+++ b/weekday/challenge_271.md
@@ -19,7 +19,7 @@ total_volume([1, 1, 1]) ➞ 1
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_272.md
+++ b/weekday/challenge_272.md
@@ -17,7 +17,7 @@ same_vowel_group(["hoops", "chuff", "bot", "bottom"]) ➞ ["hoops", "bot", "bott
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_273.md
+++ b/weekday/challenge_273.md
@@ -18,7 +18,7 @@ character_mapping("hmmmmm") ➞ [0, 1, 1, 1, 1, 1]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_274.md
+++ b/weekday/challenge_274.md
@@ -18,7 +18,7 @@ last([1, 2, 3, 4, 5], 0) ➞ []
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_275.md
+++ b/weekday/challenge_275.md
@@ -21,7 +21,7 @@ puzzle_pieces([9, 8, 7], [7, 8, 9, 10]) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_276.md
+++ b/weekday/challenge_276.md
@@ -24,7 +24,7 @@ unique_abbreviations(["mo", "ma", "me"], ["moment", "many", "mean"]) ➞ True
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_277.md
+++ b/weekday/challenge_277.md
@@ -18,7 +18,7 @@ distance_to_nearest_vowel("shopper") ➞ [2, 1, 0, 1, 1, 0, 1]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_278.md
+++ b/weekday/challenge_278.md
@@ -18,7 +18,7 @@ can_build("aa", "aaa") ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_279.md
+++ b/weekday/challenge_279.md
@@ -23,7 +23,7 @@ can_build(["mean", "meany"]) ➞ True
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_280.md
+++ b/weekday/challenge_280.md
@@ -19,7 +19,7 @@ pairs([]) ➞ []
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_281.md
+++ b/weekday/challenge_281.md
@@ -18,7 +18,7 @@ column("BA") ➞ 53
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_282.md
+++ b/weekday/challenge_282.md
@@ -83,7 +83,7 @@ final(3, 3, []) ➞ [
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_283.md
+++ b/weekday/challenge_283.md
@@ -19,7 +19,7 @@ pos_neg_sort([]) ➞ []
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_284.md
+++ b/weekday/challenge_284.md
@@ -16,7 +16,7 @@ replace_next_largest([1, 0, -1, 8, -72]) ➞ [8, 1, 0, -1, -1]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_285.md
+++ b/weekday/challenge_285.md
@@ -28,7 +28,7 @@ letter_counter([
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_286.md
+++ b/weekday/challenge_286.md
@@ -14,7 +14,7 @@ builder("most awesomest") -> "Beginner.py is the most awesomest"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_287.md
+++ b/weekday/challenge_287.md
@@ -42,7 +42,7 @@ ones_infection(
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_288.md
+++ b/weekday/challenge_288.md
@@ -16,7 +16,7 @@ valid_division("0/3") ➞ True
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_289.md
+++ b/weekday/challenge_289.md
@@ -17,7 +17,7 @@ emphasize("99 red balloons!") ➞ "99 Red Balloons!"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_290.md
+++ b/weekday/challenge_290.md
@@ -48,7 +48,7 @@ construct_deconstruct("the sun") ➞ [
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_291.md
+++ b/weekday/challenge_291.md
@@ -29,7 +29,7 @@ items = {} ➞ "Timmy is here!"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_292.md
+++ b/weekday/challenge_292.md
@@ -17,7 +17,7 @@ time(rate, people, walls) ➞ 22
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_293.md
+++ b/weekday/challenge_293.md
@@ -20,7 +20,7 @@ countdown(5, "FIRE") ➞ "5. 4. 3. 2. 1. FIRE!"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_294.md
+++ b/weekday/challenge_294.md
@@ -22,7 +22,7 @@ multiply(["A", "B", "C", "D", "E"]) ➞ [
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_295.md
+++ b/weekday/challenge_295.md
@@ -14,7 +14,7 @@ fizz_buzz(15) ➞ [1, 2, "Fizz", 4, "Buzz", "Fizz", 7, 8, "Fizz", "Buzz", 11, "F
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_296.md
+++ b/weekday/challenge_296.md
@@ -28,7 +28,7 @@ greeting("Monti") ➞ "Hi! I'm a guest."
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_297.md
+++ b/weekday/challenge_297.md
@@ -21,7 +21,7 @@ is_heteromecic(156) ➞ True
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_298.md
+++ b/weekday/challenge_298.md
@@ -26,7 +26,7 @@ a1.initials ➞ "J.S"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_299.md
+++ b/weekday/challenge_299.md
@@ -24,7 +24,7 @@ operation("6", "3", "divide") ➞ "2"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_300.md
+++ b/weekday/challenge_300.md
@@ -31,7 +31,7 @@ square_patch(0) ➞ []
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_301.md
+++ b/weekday/challenge_301.md
@@ -14,7 +14,7 @@ match_last_item([8, "thunder", True, "8thunderTrue"]) ➞ True
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_302.md
+++ b/weekday/challenge_302.md
@@ -20,7 +20,7 @@ get_identity_matrix(0) ➞ []
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_303.md
+++ b/weekday/challenge_303.md
@@ -23,7 +23,7 @@ get_list_of_sums([10, 20, 30, 40, 50, 60]) ➞ [200, 190, 180, 170, 160, 150]
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_304.md
+++ b/weekday/challenge_304.md
@@ -20,7 +20,7 @@ i_sqrt(-1) ➞ "invalid"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_305.md
+++ b/weekday/challenge_305.md
@@ -13,7 +13,7 @@ n1.threes ➞ 1
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_306.md
+++ b/weekday/challenge_306.md
@@ -18,7 +18,7 @@ to_scottish_screaming("Butterflies are beautiful!") ➞ "BETTERFLEES ERE BEEETEF
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_307.md
+++ b/weekday/challenge_307.md
@@ -14,7 +14,7 @@ consecutive_combo([44, 46], [45]) ➞ True
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_308.md
+++ b/weekday/challenge_308.md
@@ -16,7 +16,7 @@ to_list({}) ➞ []
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_309.md
+++ b/weekday/challenge_309.md
@@ -14,7 +14,7 @@ add_less("ruth") ➞ "ruthless"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_310.md
+++ b/weekday/challenge_310.md
@@ -33,7 +33,7 @@ completely_filled([
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_311.md
+++ b/weekday/challenge_311.md
@@ -17,7 +17,7 @@ check_square_and_cube([9, 27]) ➞ True
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_312.md
+++ b/weekday/challenge_312.md
@@ -16,7 +16,7 @@ Composer.count ➞ 3
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_313.md
+++ b/weekday/challenge_313.md
@@ -16,7 +16,7 @@ which_is_larger(lambda: 505050, lambda: 5050) ➞ "f"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_314.md
+++ b/weekday/challenge_314.md
@@ -13,7 +13,7 @@ is_pandigital(112233445566778899) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_315.md
+++ b/weekday/challenge_315.md
@@ -12,7 +12,7 @@ is_central("@") ➞ True
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_316.md
+++ b/weekday/challenge_316.md
@@ -19,7 +19,7 @@ balanced([7, 5, 2, 6, 1, 0, 1, 5, 2, 7, 0, 6]) ➞ [7, 5, 2, 6, 1, 0, 1, 5, 2, 7
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_317.md
+++ b/weekday/challenge_317.md
@@ -27,7 +27,7 @@ arithmetic_operation("12 / 0") ➞ -1 # 12 / 0 = -1
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_318.md
+++ b/weekday/challenge_318.md
@@ -21,7 +21,7 @@ sum_of_vowels("Do I get the correct output?") ➞ 10
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_319.md
+++ b/weekday/challenge_319.md
@@ -25,7 +25,7 @@ get_student_most_notes([
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_320.md
+++ b/weekday/challenge_320.md
@@ -14,7 +14,7 @@ str_match_by2char("", "") ➞ 0
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_321.md
+++ b/weekday/challenge_321.md
@@ -28,7 +28,7 @@ largest_gap([13, 3, 8, 5, 5, 2, 13, 6, 14, 2, 11, 4, 10, 8, 1, 9]) ➞ 2
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_322.md
+++ b/weekday/challenge_322.md
@@ -22,7 +22,7 @@ dakiti("quie3res bebe4r dime1 e5s qu6e qu2e tu7 er8es m9i-bebe") ➞ "dime que q
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_323.md
+++ b/weekday/challenge_323.md
@@ -17,7 +17,7 @@ char_appears("She hiked in the morning, then swam in the river.", "t")
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_324.md
+++ b/weekday/challenge_324.md
@@ -16,7 +16,7 @@ even_odd_transform([1, 2, 3], 1) ➞ [3, 0, 5]
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_325.md
+++ b/weekday/challenge_325.md
@@ -23,7 +23,7 @@ calc_bundled_temp(20, "4*C") ➞ "26.9*C"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_326.md
+++ b/weekday/challenge_326.md
@@ -30,7 +30,7 @@ find_a_seat(200, [35, 23, 40, 21, 38]) ➞ -1
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_327.md
+++ b/weekday/challenge_327.md
@@ -18,7 +18,7 @@ check_perfect(97) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_328.md
+++ b/weekday/challenge_328.md
@@ -18,7 +18,7 @@ censor("aaaa aaaaa 1234 12345") ➞ "aaaa ***** 1234 *****"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_329.md
+++ b/weekday/challenge_329.md
@@ -23,7 +23,7 @@ win_round([4, 3, 4, 4, 5], [3, 2, 5, 4, 1]) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_330.md
+++ b/weekday/challenge_330.md
@@ -18,7 +18,7 @@ double_swap("128 895 556 788 999", "8", "9")
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_331.md
+++ b/weekday/challenge_331.md
@@ -12,7 +12,7 @@ num_split(100) ➞ [100, 0, 0]
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_332.md
+++ b/weekday/challenge_332.md
@@ -12,7 +12,7 @@ num_split(100) ➞ [100, 0, 0]
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_333.md
+++ b/weekday/challenge_333.md
@@ -18,7 +18,7 @@ gimme_the_letters("J-J") ➞ "J"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_334.md
+++ b/weekday/challenge_334.md
@@ -16,7 +16,7 @@ extend_vowels("Extend", 0) ➞ "Extend"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_335.md
+++ b/weekday/challenge_335.md
@@ -17,7 +17,7 @@ math_expr("4*no") ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_336.md
+++ b/weekday/challenge_336.md
@@ -24,7 +24,7 @@ get_days(
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_337.md
+++ b/weekday/challenge_337.md
@@ -32,7 +32,7 @@ sort_dates(["09-02-2000_10:03", "10-02-2000_18:29", "01-01-1999_00:55"], "ASC") 
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_338.md
+++ b/weekday/challenge_338.md
@@ -23,7 +23,7 @@ digit_distance(10, 20) ➞ 1
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_339.md
+++ b/weekday/challenge_339.md
@@ -14,7 +14,7 @@ can_be_consecutive([5, 6, 7, 8, 9, 9]) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_340.md
+++ b/weekday/challenge_340.md
@@ -27,7 +27,7 @@ batting_avg([[2, 3], [1, 5], [2, 4], [1, 5], [0, 5]]) ➞ ".273"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_341.md
+++ b/weekday/challenge_341.md
@@ -20,7 +20,7 @@ is_letter_sum_even("alexa") ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_342.md
+++ b/weekday/challenge_342.md
@@ -28,7 +28,7 @@ tic_tac_toe([
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_343.md
+++ b/weekday/challenge_343.md
@@ -18,7 +18,7 @@ club_entry("bee") ➞ 20
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_344.md
+++ b/weekday/challenge_344.md
@@ -12,7 +12,7 @@ percentage_changed("$100", "$950") ➞ "850% increase"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_345.md
+++ b/weekday/challenge_345.md
@@ -38,7 +38,7 @@ peel_layer_off([
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_346.md
+++ b/weekday/challenge_346.md
@@ -27,7 +27,7 @@ calculate_arrowhead([">>>", "<<<"]) ➞ ""
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_347.md
+++ b/weekday/challenge_347.md
@@ -22,7 +22,7 @@ reversed_binary_integer(45) ➞ 45
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_348.md
+++ b/weekday/challenge_348.md
@@ -12,7 +12,7 @@ longest_word("Forgetfulness is by all means powerless!") ➞ "Forgetfulness"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_349.md
+++ b/weekday/challenge_349.md
@@ -12,7 +12,7 @@ remove_repeats("nananana") ➞ "nananana"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_350.md
+++ b/weekday/challenge_350.md
@@ -16,7 +16,7 @@ cap_last("HELp THe LASt LETTERs CAPITALISe") ➞ "HELP THE LAST LETTERS CAPITALI
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_351.md
+++ b/weekday/challenge_351.md
@@ -19,7 +19,7 @@ get_drink_id("passion fruit", "750ml") ➞ "PASFRU750"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_352.md
+++ b/weekday/challenge_352.md
@@ -39,7 +39,7 @@ _______#
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_353.md
+++ b/weekday/challenge_353.md
@@ -30,7 +30,7 @@ just_another_sum_problem(90, 45) ➞ 3105
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_354.md
+++ b/weekday/challenge_354.md
@@ -14,7 +14,7 @@ common_elements([1, 2, 3, 4, 5], [10, 12, 13, 15]) ➞ []
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_355.md
+++ b/weekday/challenge_355.md
@@ -21,7 +21,7 @@ abbreviate("the acronym of long word lengths", 5) ➞ "AL"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_356.md
+++ b/weekday/challenge_356.md
@@ -19,7 +19,7 @@ validate_subsets([[1, 2, 3, 4]], [1, 2, 3]) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_357.md
+++ b/weekday/challenge_357.md
@@ -33,7 +33,7 @@ record_temps([[34, 82], [24, 82], [20, 89],  [5, 88],  [9, 88], [26, 89], [27, 8
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_358.md
+++ b/weekday/challenge_358.md
@@ -18,7 +18,7 @@ sum_every_nth([6, 8, 9, 4, 6, 4, 7, 1, 5, 6, 10, 2], 13) ➞ 0
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_359.md
+++ b/weekday/challenge_359.md
@@ -25,7 +25,7 @@ HP.get_author() ➞ "Author: J.K. Rowling"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_360.md
+++ b/weekday/challenge_360.md
@@ -23,7 +23,7 @@ letters_only("") ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_361.md
+++ b/weekday/challenge_361.md
@@ -17,7 +17,7 @@ reverse_words("a good   example") ➞ "example good a"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_362.md
+++ b/weekday/challenge_362.md
@@ -20,7 +20,7 @@ longest_substring("721449827599186159274227324466") ➞ "7214"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_363.md
+++ b/weekday/challenge_363.md
@@ -18,7 +18,7 @@ shared_letters("house", "villa") ➞ ""
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_364.md
+++ b/weekday/challenge_364.md
@@ -17,7 +17,7 @@ num_of_leapyears("1600-2000") ➞ 98
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_365.md
+++ b/weekday/challenge_365.md
@@ -21,7 +21,7 @@ is_slidey(1357) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_366.md
+++ b/weekday/challenge_366.md
@@ -19,7 +19,7 @@ accumulating_product([]) ➞ []
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_367.md
+++ b/weekday/challenge_367.md
@@ -26,7 +26,7 @@ fibonacci(12) ➞ 233
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_368.md
+++ b/weekday/challenge_368.md
@@ -29,7 +29,7 @@ parse_code("Thomas00LEE0000043") ➞ {
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_369.md
+++ b/weekday/challenge_369.md
@@ -16,7 +16,7 @@ duplicate_nums([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) ➞ None
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_370.md
+++ b/weekday/challenge_370.md
@@ -32,7 +32,7 @@ filter_by_rating({
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_371.md
+++ b/weekday/challenge_371.md
@@ -17,7 +17,7 @@ reverse_odd("Make sure uoy only esrever sdrow of ddo length")
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_372.md
+++ b/weekday/challenge_372.md
@@ -36,7 +36,7 @@ get_birthday_cake("Isabelle", 2) ➞ [
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_373.md
+++ b/weekday/challenge_373.md
@@ -16,7 +16,7 @@ all_prime([1, 5, 3]) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_374.md
+++ b/weekday/challenge_374.md
@@ -12,7 +12,7 @@ median([1, 2, 2, 4, 7, 8, 9, 10]) ➞ 5.5
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_375.md
+++ b/weekday/challenge_375.md
@@ -32,7 +32,7 @@ split_bunches([
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_376.md
+++ b/weekday/challenge_376.md
@@ -21,7 +21,7 @@ divisible_by_left(635) ➞ [False, False, False]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_377.md
+++ b/weekday/challenge_377.md
@@ -16,7 +16,7 @@ eval_factorial(["0!", "1!"]) ➞ 2
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_378.md
+++ b/weekday/challenge_378.md
@@ -16,7 +16,7 @@ monkey_talk("Programming is Amazing") ➞ "Ook eek eek."
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_379.md
+++ b/weekday/challenge_379.md
@@ -12,7 +12,7 @@ power_of_two(18) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_380.md
+++ b/weekday/challenge_380.md
@@ -25,7 +25,7 @@ true_equations(["1+1=2", "2+2=3", "5*5=10", "3/3=1"]) ➞ ["1+1=2", "3/3=1"]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_381.md
+++ b/weekday/challenge_381.md
@@ -16,7 +16,7 @@ join_digits(15) ➞ "1-2-3-4-5-6-7-8-9-1-0-1-1-1-2-1-3-1-4-1-5"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_382.md
+++ b/weekday/challenge_382.md
@@ -19,7 +19,7 @@ alphabet_index("We have a lot of rain in June.")
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_383.md
+++ b/weekday/challenge_383.md
@@ -23,7 +23,7 @@ reverse_sort("Programming in Python is a lot of fun.")
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_384.md
+++ b/weekday/challenge_384.md
@@ -20,7 +20,7 @@ rps("Paper", "Paper") ➞ "It's a draw"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_385.md
+++ b/weekday/challenge_385.md
@@ -18,7 +18,7 @@ ends_add_to_10([]) ➞ 0
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_386.md
+++ b/weekday/challenge_386.md
@@ -16,7 +16,7 @@ check_sum([2, 8, 9, 12, 45, 78], 1) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_387.md
+++ b/weekday/challenge_387.md
@@ -30,7 +30,7 @@ standard_deviation([-3, -5, -7]) ➞ 1.63
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_388.md
+++ b/weekday/challenge_388.md
@@ -17,7 +17,7 @@ make_sandwich(["ham", "ham"], "ham") ➞ ["bread", "ham", "bread", "bread", "ham
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_389.md
+++ b/weekday/challenge_389.md
@@ -18,7 +18,7 @@ check(dict_first, dict_second, "sun") ➞ "Not the same"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_390.md
+++ b/weekday/challenge_390.md
@@ -12,7 +12,7 @@ josephus(41) ➞ 19
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_391.md
+++ b/weekday/challenge_391.md
@@ -20,7 +20,7 @@ will_fit(["L", "L", "M"], [56, 62, 84, 90]) ➞ True
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_392.md
+++ b/weekday/challenge_392.md
@@ -38,7 +38,7 @@ percent_filled([
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_393.md
+++ b/weekday/challenge_393.md
@@ -17,7 +17,7 @@ sum_missing_numbers([10, 20, 30, 40, 50, 60]) ➞ 1575
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_394.md
+++ b/weekday/challenge_394.md
@@ -21,7 +21,7 @@ reverse_complement("CAGGU") ➞ "ACCUG"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_395.md
+++ b/weekday/challenge_395.md
@@ -18,7 +18,7 @@ rectangles(3) ➞ 36
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_396.md
+++ b/weekday/challenge_396.md
@@ -17,7 +17,7 @@ first_n_vowels("hostess", 5) ➞ "invalid"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_397.md
+++ b/weekday/challenge_397.md
@@ -20,7 +20,7 @@ make_happy("print('x(')") ➞ "print('x)')"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_398.md
+++ b/weekday/challenge_398.md
@@ -18,7 +18,7 @@ unrepeated("call 911") ➞ "cal 91"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_399.md
+++ b/weekday/challenge_399.md
@@ -18,7 +18,7 @@ find_broken_keys("beethoven", "affthoif5") ➞ ["b", "e", "v", "n"]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_400.md
+++ b/weekday/challenge_400.md
@@ -41,7 +41,7 @@ freed_prisoners([0, 1, 1, 1]) ➞ 0
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_401.md
+++ b/weekday/challenge_401.md
@@ -14,7 +14,7 @@ split_code("SRPE5532") ➞ ["SRPE", 5532]
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_402.md
+++ b/weekday/challenge_402.md
@@ -53,7 +53,7 @@ tallest_building_height([
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_403.md
+++ b/weekday/challenge_403.md
@@ -30,7 +30,7 @@ score = 2+5+5+4+6+3+4+5+4+3+5+4+4+4+5+1+5+4 = 73
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_404.md
+++ b/weekday/challenge_404.md
@@ -29,7 +29,7 @@ empty_values([None]) ➞ [None]
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_405.md
+++ b/weekday/challenge_405.md
@@ -12,7 +12,7 @@ is_anti_list([3.14, True, 3.14], [3.14, False, 3.14]) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_406.md
+++ b/weekday/challenge_406.md
@@ -19,7 +19,7 @@ moving_partition([]) ➞ []
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_407.md
+++ b/weekday/challenge_407.md
@@ -15,7 +15,7 @@ sum_digits(10, 12) ➞ 6
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_408.md
+++ b/weekday/challenge_408.md
@@ -13,7 +13,7 @@ happy_year(2021) ➞ 2031
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_409.md
+++ b/weekday/challenge_409.md
@@ -16,7 +16,7 @@ half_a_fraction("3/8") ➞ "3/16"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_410.md
+++ b/weekday/challenge_410.md
@@ -22,7 +22,7 @@ simple_numbers(90, 100) ➞ []
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_411.md
+++ b/weekday/challenge_411.md
@@ -16,7 +16,7 @@ is_full_house(["7", "J", "3", "4", "2"]) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_412.md
+++ b/weekday/challenge_412.md
@@ -14,7 +14,7 @@ is_valid_phone_number("098) 123 4567") ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_413.md
+++ b/weekday/challenge_413.md
@@ -30,7 +30,7 @@ color_pattern_times(["Blue", "Blue", "Blue", "Red", "Red", "Red"]) ➞ 13
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_414.md
+++ b/weekday/challenge_414.md
@@ -17,7 +17,7 @@ validate_spelling("H. A. N. K. E. R. C. H. E. I. F. Handkerchief.") ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_415.md
+++ b/weekday/challenge_415.md
@@ -28,7 +28,7 @@ letter_distance("abcde", "bcdef") ➞ 5
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_416.md
+++ b/weekday/challenge_416.md
@@ -14,7 +14,7 @@ format_ascii("^^^^^^^^", 1) ➞ "^\n^\n^\n^\n^\n^\n^\n^"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_417.md
+++ b/weekday/challenge_417.md
@@ -21,7 +21,7 @@ product([2, 8, 8, 8]) ➞ 16
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_418.md
+++ b/weekday/challenge_418.md
@@ -16,7 +16,7 @@ delete_occurrences([True, True, True], 3) ➞ [True, True, True]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_419.md
+++ b/weekday/challenge_419.md
@@ -32,7 +32,7 @@ parts_sums([744125, 935, 407, 454, 430, 90, 144, 6710213, 889, 810, 2579358])
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_420.md
+++ b/weekday/challenge_420.md
@@ -17,7 +17,7 @@ bound_sort([1, 9, 2, 5, 7], [0, 3]) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_421.md
+++ b/weekday/challenge_421.md
@@ -18,7 +18,7 @@ is_scalable([2, 9, 11, 10, 18, 21]) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_422.md
+++ b/weekday/challenge_422.md
@@ -20,7 +20,7 @@ is_positive_dominant([0, -4, -1]) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_423.md
+++ b/weekday/challenge_423.md
@@ -21,7 +21,7 @@ security("TTxxxx$xxGxx$Gxxx") ➞ "ALARM!"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_424.md
+++ b/weekday/challenge_424.md
@@ -17,7 +17,7 @@ dashed("Fight for your right to party!") ➞ "F-i-ght f-o-r y-o--u-r r-i-ght t-o
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_425.md
+++ b/weekday/challenge_425.md
@@ -24,7 +24,7 @@ organize("") ➞ {}
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_426.md
+++ b/weekday/challenge_426.md
@@ -24,7 +24,7 @@ greater_than_sum([1, 2, 4, 6, 13]) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_427.md
+++ b/weekday/challenge_427.md
@@ -26,7 +26,7 @@ number_of_days([-1, -2]) ➞ 3
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_428.md
+++ b/weekday/challenge_428.md
@@ -12,7 +12,7 @@ checkout([
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_429.md
+++ b/weekday/challenge_429.md
@@ -16,7 +16,7 @@ insert_whitespace("TheGreatestUpsetInHistory") ➞ "The Greatest Upset In Histor
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_430.md
+++ b/weekday/challenge_430.md
@@ -40,7 +40,7 @@ pirates_killed([3, 3, 10], [6, 6, 0]) ➞ True
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_431.md
+++ b/weekday/challenge_431.md
@@ -29,7 +29,7 @@ p1.taste("carrots") ➞ "Sam eats the carrots and hates it!"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_432.md
+++ b/weekday/challenge_432.md
@@ -40,7 +40,7 @@ time_to_finish(
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_433.md
+++ b/weekday/challenge_433.md
@@ -16,7 +16,7 @@ average_word_length("Dude, this is so awesome!") ➞ 3.80
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_434.md
+++ b/weekday/challenge_434.md
@@ -12,7 +12,7 @@ prime_factors(8912234) ➞ [2, 47, 94811]
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_435.md
+++ b/weekday/challenge_435.md
@@ -18,7 +18,7 @@ twins([3, 3]) ➞ 1
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_436.md
+++ b/weekday/challenge_436.md
@@ -18,7 +18,7 @@ chunk([1, 2, 3, 4 ,5], 10) ➞ [
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_437.md
+++ b/weekday/challenge_437.md
@@ -12,7 +12,7 @@ count_repetitions(["Infinity", "null", "Infinity", "null", "null"]) ➞ { "null"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_438.md
+++ b/weekday/challenge_438.md
@@ -17,7 +17,7 @@ switcheroo("Bounced over the fence!") ➞ "Bounced over the fents!"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_439.md
+++ b/weekday/challenge_439.md
@@ -17,7 +17,7 @@ initialize(["Sherlock Holmes", "John Watson", "Irene Adler"]) ➞ ["S. H.", "J. 
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_440.md
+++ b/weekday/challenge_440.md
@@ -17,7 +17,7 @@ same_vowel_group(["hoops", "chuff", "bot", "bottom"]) ➞ ["hoops", "bot", "bott
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_441.md
+++ b/weekday/challenge_441.md
@@ -17,7 +17,7 @@ merge_and_sort([120, 180, 200], [190, 175, 130]) ➞ [120, 130, 175, 180, 190, 2
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_442.md
+++ b/weekday/challenge_442.md
@@ -20,7 +20,7 @@ vowels("Smithsonian") ➞ 4
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 ```python

--- a/weekday/challenge_443.md
+++ b/weekday/challenge_443.md
@@ -22,7 +22,7 @@ flash(10, "/", 3) ➞ 3.33
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_444.md
+++ b/weekday/challenge_444.md
@@ -17,7 +17,7 @@ sort_drinks_by_price(drinks) ➞ [{"name": "lime", "price": 10}, {"name": "lemon
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_445.md
+++ b/weekday/challenge_445.md
@@ -19,7 +19,7 @@ smallest(2, 3) ➞ 12
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_446.md
+++ b/weekday/challenge_446.md
@@ -20,7 +20,7 @@ unique_abbrev(["mo", "ma", "me"], ["moment", "many", "mean"]) ➞ True
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_447.md
+++ b/weekday/challenge_447.md
@@ -15,7 +15,7 @@ same_upsidedown("69069069") ➞ True
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_448.md
+++ b/weekday/challenge_448.md
@@ -31,7 +31,7 @@ wurst_is_better("Bratwurst and Rostbratwurst are sausages") ➞ "Bratwurst and R
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_449.md
+++ b/weekday/challenge_449.md
@@ -38,7 +38,7 @@ bingo_check([
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_450.md
+++ b/weekday/challenge_450.md
@@ -27,7 +27,7 @@ fire(matrix, "D2") ➞ "BOOM"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_451.md
+++ b/weekday/challenge_451.md
@@ -35,7 +35,7 @@ describe_num(60) ➞ "The most brilliant exciting fantastic virtuous heart-warmi
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_452.md
+++ b/weekday/challenge_452.md
@@ -49,7 +49,7 @@ is_legitimate([
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_453.md
+++ b/weekday/challenge_453.md
@@ -27,7 +27,7 @@ climb(10, [5, 4.2, 3, 3.5, 6, 4, 6, 8, 1]) ➞ 3
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_454.md
+++ b/weekday/challenge_454.md
@@ -37,7 +37,7 @@ is_unfair_hurdle([
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_455.md
+++ b/weekday/challenge_455.md
@@ -18,7 +18,7 @@ first_repeat("Isildur") ➞ "-1"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_456.md
+++ b/weekday/challenge_456.md
@@ -33,7 +33,7 @@ simple_check(54, 17) ➞ 1
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_457.md
+++ b/weekday/challenge_457.md
@@ -38,7 +38,7 @@ shuffle_count(52) ➞ 8
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_458.md
+++ b/weekday/challenge_458.md
@@ -31,7 +31,7 @@ n_differences([5, 8, 8]) ➞ -3
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_459.md
+++ b/weekday/challenge_459.md
@@ -16,7 +16,7 @@ rotated_words("OS IS UPDATED") ➞ 2
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_460.md
+++ b/weekday/challenge_460.md
@@ -40,7 +40,7 @@ champions([
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_461.md
+++ b/weekday/challenge_461.md
@@ -32,7 +32,7 @@ reverse_image([
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_462.md
+++ b/weekday/challenge_462.md
@@ -33,7 +33,7 @@ antipodes_average([-1, -2]) ➞ [-1.5]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_463.md
+++ b/weekday/challenge_463.md
@@ -14,7 +14,7 @@ invert("XeLPMoC YTiReTXeD") ➞ "dExtErIty cOmplEx"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_464.md
+++ b/weekday/challenge_464.md
@@ -22,7 +22,7 @@ count_smileys([";]", ":[", ";*", ":$", ";-D"]) ➞ 1
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_465.md
+++ b/weekday/challenge_465.md
@@ -16,7 +16,7 @@ deepest([1, 4, [1, 4, [1, 4, [1, 4, [5]]]]]) ➞ 5
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_466.md
+++ b/weekday/challenge_466.md
@@ -47,7 +47,7 @@ total_sales([
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_467.md
+++ b/weekday/challenge_467.md
@@ -16,7 +16,7 @@ can_concatenate([[2, 1, 3], [5, 4, 7]], [1, 2, 3, 4, 5, 6, 7]) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_468.md
+++ b/weekday/challenge_468.md
@@ -18,7 +18,7 @@ min_swaps("10011001", "01100110") ➞ 4
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_469.md
+++ b/weekday/challenge_469.md
@@ -31,7 +31,7 @@ bill_split(["S", "N"], [41, 10]) ➞ [46, 5]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_470.md
+++ b/weekday/challenge_470.md
@@ -26,7 +26,7 @@ nearest_chapter({
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_471.md
+++ b/weekday/challenge_471.md
@@ -20,7 +20,7 @@ parity_analysis(3) ➞ True
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_472.md
+++ b/weekday/challenge_472.md
@@ -19,7 +19,7 @@ get_missing_letters("abcdefghijklmnopqrstuvwxyz") ➞ ""
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_473.md
+++ b/weekday/challenge_473.md
@@ -28,7 +28,7 @@ intersection_union([1, 1], [1, 1, 1, 1]) ➞ [[1], [1]]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_474.md
+++ b/weekday/challenge_474.md
@@ -23,7 +23,7 @@ digit_count(2) ➞ 1
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_475.md
+++ b/weekday/challenge_475.md
@@ -21,7 +21,7 @@ eng2nums("seven hundred sixty seven") ➞ 767
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_476.md
+++ b/weekday/challenge_476.md
@@ -23,7 +23,7 @@ chess_board("d1") ➞ "white"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_477.md
+++ b/weekday/challenge_477.md
@@ -14,7 +14,7 @@ sort_by_character(["mate", "team", "bade"], 3) ➞ ["team", "bade", "mate"]
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_478.md
+++ b/weekday/challenge_478.md
@@ -24,7 +24,7 @@ best_friend("we found your dynamite", "d", "y") ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_479.md
+++ b/weekday/challenge_479.md
@@ -18,7 +18,7 @@ high_low("13") ➞ "13 13"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_480.md
+++ b/weekday/challenge_480.md
@@ -29,7 +29,7 @@ cup_swapping(["BA", "AC", "CA", "BC"]) ➞ "A"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_481.md
+++ b/weekday/challenge_481.md
@@ -14,7 +14,7 @@ get_frequencies([]) ➞ {}
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_482.md
+++ b/weekday/challenge_482.md
@@ -10,7 +10,7 @@ upload_count(["Sept 22", "Sept 21", "Oct 15"], "Oct") ➞ 1
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_483.md
+++ b/weekday/challenge_483.md
@@ -16,7 +16,7 @@ show_the_love([2, 100]) ➞ [27, 75]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_484.md
+++ b/weekday/challenge_484.md
@@ -14,7 +14,7 @@ loves_me(1) ➞ "LOVES ME"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_485.md
+++ b/weekday/challenge_485.md
@@ -12,7 +12,7 @@ filter_words([”red”, “dee”, “cede”, “reed”, “creed”, “decr
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_486.md
+++ b/weekday/challenge_486.md
@@ -12,7 +12,7 @@ remove_dups(["John", "Taylor", "John"]) ➞ ["John", "Taylor"]
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_487.md
+++ b/weekday/challenge_487.md
@@ -21,7 +21,7 @@ matrix(3, 2, 0) ➞ [[0, 0], [0, 0], [0, 0]]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_488.md
+++ b/weekday/challenge_488.md
@@ -22,7 +22,7 @@ can_find(["oo", "mi", "ki", "la"], ["milk", "chocolate", "cooks"]) ➞ False
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_489.md
+++ b/weekday/challenge_489.md
@@ -28,7 +28,7 @@ diamond_arrays(5) ➞ [
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_490.md
+++ b/weekday/challenge_490.md
@@ -23,7 +23,7 @@ maximum_seating([1, 0, 0, 0, 0, 1]) ➞ 0
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_491.md
+++ b/weekday/challenge_491.md
@@ -24,7 +24,7 @@ how_many_missing([5, 6, 7, 8]) ➞ 0
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_492.md
+++ b/weekday/challenge_492.md
@@ -12,7 +12,7 @@ one_odd_one_even(22) ➞ False
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_493.md
+++ b/weekday/challenge_493.md
@@ -19,7 +19,7 @@ remix("computer", [0, 2, 1, 5, 3, 6, 7, 4]) ➞ "cmourpte"
 ```
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_494.md
+++ b/weekday/challenge_494.md
@@ -38,7 +38,7 @@ poker_hand_ranking(["10s", "10c", "8d", "10d", "10h"]) ➞ "Four of a Kind"
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 

--- a/weekday/challenge_495.md
+++ b/weekday/challenge_495.md
@@ -19,7 +19,7 @@ number_split(-9) ➞ [-5, -4]
 
 ## Join Us & Share Your Solution
 
-We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
+We're a community of coders who believe the best way to grow is to help others learn. **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
 
 ## Challenge Tests
 


### PR DESCRIPTION
Fixed an issue where the hyperlinks to the Beginner.codes Discord server in many of the challenge instructions were broken.

### Error
#### **Raw text:**
```
**[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**
```
**Output:** **[Join us on Discord!!!]("https"://discord.gg/sfHykntuGy)**

### Solution
The solution was to remove the quotation marks around "https".

**Raw text:**
```
**[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**
```
**Output:** **[Join us on Discord!!!](https://discord.gg/sfHykntuGy)**

I created this script to scan for the error and apply the fix to any file affected.
```py
import glob
import os

PATH = "weekday/"
KEYWORD = f'("https"://discord.gg/sfHykntuGy)'
REPLACEMENT = f'(https://discord.gg/sfHykntuGy)'

for filename in glob.glob(os.path.join(PATH, "challenge_*.md")):
    filepath = os.path.join(os.curdir, filename)
    with open(filepath, 'r') as f:
        text = f.readlines()
        for i in range(len(text)):
            if KEYWORD in text[i]:
                print(f"Found typo in {f.name}")
                text[i] = text[i].replace(KEYWORD, REPLACEMENT)
    with open(filepath, "w") as f:
        f.writelines(text)
```
